### PR TITLE
fix too many section closing tags in html when using groupby year

### DIFF
--- a/imbiber.rb
+++ b/imbiber.rb
@@ -1003,9 +1003,14 @@ class Imbiber
 				end
 				html << entry[:entry] << "\n"
 			end
-			html << "</section>\n"
-			if @idswithprefix != false then
+
+			if groupby == :year and @idswithprefix != false then
 				html << "</section>\n"
+			else
+				html << "</section>\n"
+				if @idswithprefix != false then
+					html << "</section>\n"
+				end
 			end
 		end
 


### PR DESCRIPTION
I noticed `</section>` tags are printed twice per group on my 3dsm project page where I use `groupby:year idswithprefix:year_` where they should only be printed once per group. This fixes that and should not change the behaviour for other cases.
