### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/imbiber.rb
+++ b/imbiber.rb
@@ -885,7 +885,7 @@ class Imbiber
 		end
 		if @entries[key].has_key?(:doi) then
 			if !@entries[key][:doi].start_with?("http://", "https://", "ftp://", "//") then
-				@entries[key][:doi] = "http://dx.doi.org/" + @entries[key][:doi]
+				@entries[key][:doi] = "https://doi.org/" + @entries[key][:doi]
 			end
 			out << ' <a href="' + @entries[key][:doi] + '"><i class="fa fa-external-link"></i> DOI</a>'
 		end


### PR DESCRIPTION

Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!